### PR TITLE
feat: spend over time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TheQueenIsDead/budge
 
-go 1.22
+go 1.23
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -102,6 +102,8 @@ func NewApplication(store *database.Store, integrations *integrations.Integratio
 	app.http.Static("/assets", "./web/public")
 
 	app.http.GET("/charts/timeseries", app.ChartTimeseries)
+	app.http.GET("/charts/doughnut", app.ChartDoughnut)
+	app.http.GET("/charts/gauge", app.ChartGauge)
 
 	return app, nil
 }

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -33,6 +33,7 @@ func NewApplication(store *database.Store, integrations *integrations.Integratio
 	// Setup HTTP server
 	tpl := template.Must(template.ParseGlob("web/templates/*.gohtml"))
 	tpl = template.Must(tpl.ParseGlob("web/templates/partials/*.gohtml"))
+	tpl = template.Must(tpl.ParseGlob("web/templates/charts/*.gohtml"))
 
 	t := &Template{
 		templates: tpl,
@@ -99,6 +100,8 @@ func NewApplication(store *database.Store, integrations *integrations.Integratio
 	app.http.GET("/integrations/akahu/accounts", app.ListAkahuAccounts)
 
 	app.http.Static("/assets", "./web/public")
+
+	app.http.GET("/charts/timeseries", app.ChartTimeseries)
 
 	return app, nil
 }

--- a/pkg/application/charts.go
+++ b/pkg/application/charts.go
@@ -1,6 +1,9 @@
 package application
 
-import "github.com/labstack/echo/v4"
+import (
+	"github.com/TheQueenIsDead/budge/pkg/database/models"
+	"github.com/labstack/echo/v4"
+)
 
 type TimeseriesData struct {
 	ChartId    string
@@ -12,10 +15,9 @@ type TimeseriesData struct {
 }
 
 func (app *Application) ChartTimeseries(c echo.Context) error {
-	c.Response().Header().Add("HX-Trigger", "updateChart")
-
-	config := TimeseriesData{
-		"spend_chart",
+	// TODO: Grab actual data over time
+	return c.Render(200, "chart.timeseries", TimeseriesData{
+		"timeseries_chart",
 		"My First Chart",
 		[]string{"a", "b", "c", "d", "e", "f", "g"},
 		[]int{1, 2, 3, 4, 5, 6, 7},
@@ -37,9 +39,91 @@ func (app *Application) ChartTimeseries(c echo.Context) error {
 			"rgb(153, 102, 255)",
 			"rgb(201, 203, 207)",
 		},
+	})
+}
+
+type DoughnutData struct {
+	ChartId string
+	Title   string
+	Labels  []string
+	Data    []float64
+}
+
+func (app *Application) ChartDoughnut(c echo.Context) error {
+
+	var err error
+
+	var transactions []models.Transaction
+	transactions, err = app.store.ReadTransactions()
+	if err != nil {
+		c.Logger().Error(err)
+		return err
 	}
 
-	return c.Render(200, "chart.timeseries", map[string]interface{}{
-		"config": config,
+	categories := make(map[string]float64)
+	for _, transaction := range transactions {
+		category := transaction.Category.Groups.PersonalFinance.Name
+		if category != "" {
+			categories[category] += transaction.Amount
+		}
+	}
+
+	var categoryLabels []string
+	var categoryData []float64
+	for k, v := range categories {
+		categoryLabels = append(categoryLabels, k)
+		categoryData = append(categoryData, v)
+	}
+
+	return c.Render(200, "chart.doughnut", DoughnutData{
+		ChartId: "doughnut_chart",
+		Title:   "Spend By Category",
+		Labels:  categoryLabels,
+		Data:    categoryData,
+	})
+}
+
+type GaugeData struct {
+	ChartId    string
+	Title      string
+	Labels     []string
+	Data       []float64
+	Background []string
+}
+
+func (app *Application) ChartGauge(c echo.Context) error {
+
+	var err error
+
+	var transactions []models.Transaction
+	transactions, err = app.store.ReadTransactions()
+	if err != nil {
+		c.Logger().Error(err)
+		return err
+	}
+
+	categories := make(map[string]float64)
+	var in, out float64
+	for _, transaction := range transactions {
+		if transaction.Amount < 0 {
+			out += transaction.Float()
+			category := transaction.Category.Groups.PersonalFinance.Name
+			if category != "" {
+				categories[category] += transaction.Amount
+			}
+		} else {
+			in += transaction.Float()
+		}
+	}
+
+	return c.Render(200, "chart.gauge", GaugeData{
+		ChartId: "gauge_chart",
+		Title:   "Incoming vs Outgoing",
+		Labels:  []string{"Incoming", "Outgoing"},
+		Data:    []float64{in, out},
+		Background: []string{
+			"rgb(26, 188, 156)",
+			"rgb(255, 205, 52)",
+		},
 	})
 }

--- a/pkg/application/charts.go
+++ b/pkg/application/charts.go
@@ -1,0 +1,45 @@
+package application
+
+import "github.com/labstack/echo/v4"
+
+type TimeseriesData struct {
+	ChartId    string
+	Title      string
+	Labels     []string
+	Data       []int
+	Border     []string
+	Background []string
+}
+
+func (app *Application) ChartTimeseries(c echo.Context) error {
+	c.Response().Header().Add("HX-Trigger", "updateChart")
+
+	config := TimeseriesData{
+		"spend_chart",
+		"My First Chart",
+		[]string{"a", "b", "c", "d", "e", "f", "g"},
+		[]int{1, 2, 3, 4, 5, 6, 7},
+		[]string{
+			"rgba(255, 99, 132, 0.2)",
+			"rgba(255, 159, 64, 0.2)",
+			"rgba(255, 205, 86, 0.2)",
+			"rgba(75, 192, 192, 0.2)",
+			"rgba(54, 162, 235, 0.2)",
+			"rgba(153, 102, 255, 0.2)",
+			"rgba(201, 203, 207, 0.2)",
+		},
+		[]string{
+			"rgb(255, 99, 132)",
+			"rgb(255, 159, 64)",
+			"rgb(255, 205, 86)",
+			"rgb(75, 192, 192)",
+			"rgb(54, 162, 235)",
+			"rgb(153, 102, 255)",
+			"rgb(201, 203, 207)",
+		},
+	}
+
+	return c.Render(200, "chart.timeseries", map[string]interface{}{
+		"config": config,
+	})
+}

--- a/pkg/application/charts.go
+++ b/pkg/application/charts.go
@@ -3,42 +3,72 @@ package application
 import (
 	"github.com/TheQueenIsDead/budge/pkg/database/models"
 	"github.com/labstack/echo/v4"
+	"maps"
+	"slices"
+	"time"
 )
 
 type TimeseriesData struct {
 	ChartId    string
 	Title      string
 	Labels     []string
-	Data       []int
+	Data       []float64
 	Border     []string
 	Background []string
 }
 
 func (app *Application) ChartTimeseries(c echo.Context) error {
-	// TODO: Grab actual data over time
+
+	period := c.QueryParam("period")
+	var periodDays = 7
+	switch period {
+	case "week":
+		periodDays = 7
+	case "month":
+		periodDays = 30
+	case "quarter":
+		periodDays = 31 * 4
+	}
+	queryStart := time.Now().AddDate(0, 0, -1*periodDays)
+
+	var transactions []models.Transaction
+	transactions, err := app.store.ReadTransactionsByDate(queryStart, time.Now())
+	if err != nil {
+		c.Logger().Error(err)
+		return err
+	}
+
+	// TODO: Size buckets appropriately for the period, days by default
+	buckets := map[string]float64{}
+	for _, transaction := range transactions {
+		//if transaction.Amount < 0 {
+		key := transaction.Date.Format(time.DateOnly)
+		buckets[key] += transaction.Amount
+		//}
+	}
+
+	var data []float64
+	var labels []string
+	var background []string
+	keys := slices.Collect(maps.Keys(buckets))
+	slices.Sort(keys)
+	for _, k := range keys {
+		data = append(data, buckets[k])
+		labels = append(labels, k)
+		if buckets[k] > 0 {
+			background = append(background, "rgb(26, 188, 156)")
+		} else {
+			background = append(background, "rgb(255, 205, 52)")
+		}
+	}
+
 	return c.Render(200, "chart.timeseries", TimeseriesData{
-		"timeseries_chart",
-		"My First Chart",
-		[]string{"a", "b", "c", "d", "e", "f", "g"},
-		[]int{1, 2, 3, 4, 5, 6, 7},
-		[]string{
-			"rgba(255, 99, 132, 0.2)",
-			"rgba(255, 159, 64, 0.2)",
-			"rgba(255, 205, 86, 0.2)",
-			"rgba(75, 192, 192, 0.2)",
-			"rgba(54, 162, 235, 0.2)",
-			"rgba(153, 102, 255, 0.2)",
-			"rgba(201, 203, 207, 0.2)",
-		},
-		[]string{
-			"rgb(255, 99, 132)",
-			"rgb(255, 159, 64)",
-			"rgb(255, 205, 86)",
-			"rgb(75, 192, 192)",
-			"rgb(54, 162, 235)",
-			"rgb(153, 102, 255)",
-			"rgb(201, 203, 207)",
-		},
+		ChartId:    "timeseries_chart",
+		Title:      "Spend Over Time",
+		Labels:     labels,
+		Data:       data,
+		Border:     background,
+		Background: background,
 	})
 }
 

--- a/pkg/application/home.go
+++ b/pkg/application/home.go
@@ -3,8 +3,6 @@ package application
 import (
 	"github.com/TheQueenIsDead/budge/pkg/database/models"
 	"github.com/labstack/echo/v4"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 	"net/http"
 	"sort"
 )
@@ -82,22 +80,11 @@ func (app *Application) Home(c echo.Context) error {
 		categoryData = append(categoryData, v)
 	}
 
-	var incomingString, outgoingString string
-	p := message.NewPrinter(language.English)
-	incomingString = p.Sprintf("%.2f", in)
-	outgoingString = p.Sprintf("%.2f", out)
-
 	return c.Render(http.StatusOK, "home", map[string]interface{}{
 		"accountCount":     accountCount,
 		"transactionCount": transactionCount,
 		"merchantCount":    merchantCount,
-		"incoming":         in,
-		"incomingString":   incomingString,
-		"outgoing":         out,
-		"outgoingString":   outgoingString,
 		"topMerchants":     top,
-		"category_labels":  categoryLabels,
-		"category_data":    categoryData,
 	})
 }
 func (app *Application) _4XX(c echo.Context) error {

--- a/pkg/database/wrappers.go
+++ b/pkg/database/wrappers.go
@@ -1,6 +1,9 @@
 package database
 
-import "github.com/TheQueenIsDead/budge/pkg/database/models"
+import (
+	"github.com/TheQueenIsDead/budge/pkg/database/models"
+	"time"
+)
 
 /* Accounts */
 
@@ -55,6 +58,11 @@ func (s *Store) ReadTransactions() ([]models.Transaction, error) {
 func (s *Store) ReadTransactionsByAccount(account string) ([]models.Transaction, error) {
 	return ReadFilter[models.Transaction](s.db, func(transaction models.Transaction) bool {
 		return transaction.Account == account
+	})
+}
+func (s *Store) ReadTransactionsByDate(start time.Time, end time.Time) ([]models.Transaction, error) {
+	return ReadFilter[models.Transaction](s.db, func(transaction models.Transaction) bool {
+		return transaction.Date.After(start) && transaction.Date.Before(end)
 	})
 }
 

--- a/web/templates/charts/doughnut.gohtml
+++ b/web/templates/charts/doughnut.gohtml
@@ -1,0 +1,35 @@
+{{define "chart.doughnut"}}
+<canvas id="{{.ChartId}}"  style="min-width: 300px; max-width: 400px">
+</canvas>
+<script>
+
+    function render() {
+        const data = {
+            labels: {{.Labels}},
+            datasets: [{
+                data: {{ .Data }},
+                hoverOffset: 4,
+            }]
+        };
+        const config = {
+            type: 'doughnut',
+            data: data,
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    title: {
+                        display: true,
+                        text: {{.Title}}
+                    }
+                },
+                legend: {
+                    display: true,
+                }
+            }
+        };
+        new Chart(document.getElementById({{.ChartId}}), config);
+    }
+    render()
+</script>
+{{end}}

--- a/web/templates/charts/gauge.gohtml
+++ b/web/templates/charts/gauge.gohtml
@@ -1,0 +1,38 @@
+{{define "chart.gauge"}}
+<canvas id="{{.ChartId}}"  style="min-width: 300px; max-width: 400px">
+</canvas>
+<script>
+    function render() {
+        const data = {
+            labels: {{.Labels}},
+            datasets: [{
+                label: {{.Title}},
+                data: {{.Data}},
+                backgroundColor: {{.Background}},
+                hoverOffset: 4,
+                circumference: 180,
+                rotation: -90
+            }]
+        };
+        const config = {
+            type: 'doughnut',
+            data: data,
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    title: {
+                        display: true,
+                        text: {{.Title}},
+                    }
+                },
+                legend: {
+                    display: false,
+                }
+            }
+        };
+        new Chart(document.getElementById({{.ChartId}}), config);
+    }
+    render()
+</script>
+{{end}}

--- a/web/templates/charts/timeseries.gohtml
+++ b/web/templates/charts/timeseries.gohtml
@@ -1,25 +1,27 @@
 {{define "chart.timeseries"}}
-<canvas id="{{.config.ChartId}}">
+<canvas id="{{.ChartId}}">
 </canvas>
 <script>
-
-    function spendChart() {
-        const spend_data = {
-            labels: {{.config.Labels}},
+    function render() {
+        const data = {
+            labels: {{.Labels}},
             datasets: [
                 {
-                    label: {{.config.Title}},
-                    data: {{.config.Data}},
-                    backgroundColor: {{.config.Background}},
-                    borderColor: {{.config.Border}},
+                    label: {{.Title}},
+                    data: {{.Data}},
+                    backgroundColor: {{.Background}},
+                    borderColor: {{.Border}},
                     borderWidth: 1
                 }
             ]
         };
-        const spend_config = {
+        const config = {
             type: 'bar',
-            data: spend_data,
+            data: data,
             options: {
+                // animation: {
+                //     duration: 0,
+                // },
                 scales: {
                     y: {
                         beginAtZero: true
@@ -27,9 +29,8 @@
                 }
             },
         };
-        new Chart(document.getElementById({{.config.ChartId}}), spend_config);
+        new Chart(document.getElementById({{.ChartId}}), config);
     }
-    spendChart()
+    render()
 </script>
-
 {{end}}

--- a/web/templates/charts/timeseries.gohtml
+++ b/web/templates/charts/timeseries.gohtml
@@ -1,0 +1,35 @@
+{{define "chart.timeseries"}}
+<canvas id="{{.config.ChartId}}">
+</canvas>
+<script>
+
+    function spendChart() {
+        const spend_data = {
+            labels: {{.config.Labels}},
+            datasets: [
+                {
+                    label: {{.config.Title}},
+                    data: {{.config.Data}},
+                    backgroundColor: {{.config.Background}},
+                    borderColor: {{.config.Border}},
+                    borderWidth: 1
+                }
+            ]
+        };
+        const spend_config = {
+            type: 'bar',
+            data: spend_data,
+            options: {
+                scales: {
+                    y: {
+                        beginAtZero: true
+                    }
+                }
+            },
+        };
+        new Chart(document.getElementById({{.config.ChartId}}), spend_config);
+    }
+    spendChart()
+</script>
+
+{{end}}

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -76,6 +76,23 @@
             </div>
         </div>
 
+        <div class="container">
+            <div class="row">
+                <h1>Spend Over Time</h1>
+                <div class="btn-group" role="group" aria-label="Basic outlined example">
+                    <button type="button" class="btn btn-outline-primary">Week</button>
+                    <button type="button" class="btn btn-outline-primary">Month</button>
+                    <button type="button" class="btn btn-outline-primary">Quarter</button>
+                </div>
+            </div>
+            <div class="col">
+                <canvas id="spend_chart" style="min-width: 300px"></canvas>
+            </div>
+
+        </div>
+
+
+
         <hr>
 
         {{/*TODO: Instead of showing this in a table, we could use progress bars to display relative spends.*/}}
@@ -173,6 +190,87 @@
             new Chart(document.getElementById('categories_chart'), categories_config);
         }
         categoriesChart()
+    </script>
+
+
+    {{/*Spend Chart*/}}
+    <script>
+
+        function spendChart() {
+
+
+            const MONTHS = [
+                'January',
+                'February',
+                'March',
+                'April',
+                'May',
+                'June',
+                'July',
+                'August',
+                'September',
+                'October',
+                'November',
+                'December'
+            ];
+
+            function months(config) {
+                var cfg = config || {};
+                var count = cfg.count || 12;
+                var section = cfg.section;
+                var values = [];
+                var i, value;
+
+                for (i = 0; i < count; ++i) {
+                    value = MONTHS[Math.ceil(i) % 12];
+                    values.push(value.substring(0, section));
+                }
+
+                return values;
+            }
+
+
+            const spend_labels = months({count: 7});
+            const spend_data = {
+                labels: spend_labels,
+                datasets: [{
+                    label: 'My First Dataset',
+                    data: [65, 59, 80, 81, 56, 55, 40],
+                    backgroundColor: [
+                        'rgba(255, 99, 132, 0.2)',
+                        'rgba(255, 159, 64, 0.2)',
+                        'rgba(255, 205, 86, 0.2)',
+                        'rgba(75, 192, 192, 0.2)',
+                        'rgba(54, 162, 235, 0.2)',
+                        'rgba(153, 102, 255, 0.2)',
+                        'rgba(201, 203, 207, 0.2)'
+                    ],
+                    borderColor: [
+                        'rgb(255, 99, 132)',
+                        'rgb(255, 159, 64)',
+                        'rgb(255, 205, 86)',
+                        'rgb(75, 192, 192)',
+                        'rgb(54, 162, 235)',
+                        'rgb(153, 102, 255)',
+                        'rgb(201, 203, 207)'
+                    ],
+                    borderWidth: 1
+                }]
+            };
+            const spend_config = {
+                type: 'bar',
+                data: spend_data,
+                options: {
+                    scales: {
+                        y: {
+                            beginAtZero: true
+                        }
+                    }
+                },
+            };
+            new Chart(document.getElementById('spend_chart'), spend_config);
+        }
+        spendChart()
     </script>
 
 {{end}}

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -71,17 +71,20 @@
             </div>
         </div>
 
+        {{/* FIXME: When swapping between time periods, the chart can fail to adjust it's size appropriately and get blown out.
+                double clicking, or changing the period helps. Perhaps we should send the current dimensions in the request?
+                 ChartJS sets the style on resize, it seems, ex: style="height: 699px; width: 648px; display: block; box-sizing: border-box;" */}}
         <div class="container">
             <div class="row">
                 <h1>Spend Over Time</h1>
                 <div class="btn-group" role="group" aria-label="Basic outlined example">
-                    <button type="button" class="btn btn-outline-primary">Week</button>
-                    <button type="button" class="btn btn-outline-primary">Month</button>
-                    <button type="button" class="btn btn-outline-primary">Quarter</button>
+                    <button type="button" class="btn btn-outline-primary active" hx-get="/charts/timeseries?period=week" hx-target="#spendOverTime" _="on click remove .active from <button/> add .active">Week</button>
+                    <button type="button" class="btn btn-outline-primary" hx-get="/charts/timeseries?period=month" hx-target="#spendOverTime" _="on click remove .active from <button/> add .active">Month</button>
+                    <button type="button" class="btn btn-outline-primary" hx-get="/charts/timeseries?period=quarter" hx-target="#spendOverTime" _="on click remove .active from <button/> add .active">Quarter</button>
                 </div>
             </div>
 
-            <div class="col" hx-trigger="load" hx-get="/charts/timeseries" hx-swap="innerHtml"></div>
+            <div id="spendOverTime" class="col" hx-trigger="load" hx-get="/charts/timeseries" hx-swap="innerHtml"></div>
         </div>
 
         <hr>

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -66,13 +66,8 @@
                 {{/*                    </h3>*/}}
                 {{/*                </div>*/}}
 
-                <div class="col-12 col-md-6">
-                    <canvas id="chart" style="min-width: 300px; max-width: 400px"></canvas>
-                </div>
-
-                <div class="col-12 col-md-6">
-                    <canvas id="categories_chart" style="min-width: 300px; max-width: 400px"></canvas>
-                </div>
+                <div class="col-12 col-md-6" hx-trigger="load" hx-get="/charts/gauge" hx-swap="innerHtml"></div>
+                <div class="col-12 col-md-6" hx-trigger="load" hx-get="/charts/doughnut" hx-swap="innerHtml"></div>
             </div>
         </div>
 
@@ -85,24 +80,9 @@
                     <button type="button" class="btn btn-outline-primary">Quarter</button>
                 </div>
             </div>
-{{/*            <div class="col">*/}}
-{{/*                <canvas id="spend_chart" style="min-width: 300px"></canvas>*/}}
-{{/*            </div>*/}}
 
-            <div class="col" hx-trigger="load" hx-get="/charts/timeseries" hx-swap="outerHtml">
-                <canvas id="spend_chart" style="min-width: 300px"></canvas>
-            </div>
-
-            <div _="on updateChart log event.detail"></div>
-
+            <div class="col" hx-trigger="load" hx-get="/charts/timeseries" hx-swap="innerHtml"></div>
         </div>
-
-        <script>
-            document.body.addEventListener("updateChart", function (evt) {
-                console.log(evt)
-
-            })
-        </script>
 
         <hr>
 
@@ -125,163 +105,4 @@
             </tbody>
         </table>
     </div>
-
-    {{/* Incoming vs Outgoing Chart*/}}
-    <script>
-        function incomingOutgoingChart() {
-            const data = {
-                labels: [
-                    'Incoming',
-                    'Outgoing'
-                ],
-                datasets: [{
-                    label: 'Expenditure',
-                    data: [{{.incoming}}, {{.outgoing}}],
-                    backgroundColor: [
-                        'rgb(26, 188, 156)',
-                        'rgb(255, 205, 52)'
-                    ],
-                    hoverOffset: 4,
-                    circumference: 180,
-                    rotation: -90
-                }]
-            };
-            const config = {
-                type: 'doughnut',
-                data: data,
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    plugins: {
-                        title: {
-                            display: true,
-                            text: "Incoming vs Outgoing"
-                        }
-                    },
-                    legend: {
-                        display: false,
-                    }
-                }
-            };
-
-            new Chart(document.getElementById('chart'), config)
-        }
-        incomingOutgoingChart()
-
-    </script>
-
-    {{/*Categories Chart*/}}
-    <script>
-        function categoriesChart() {
-            const categories_data = {
-                labels: {{.category_labels}},
-                datasets: [{
-                    data: {{ .category_data }},
-                    hoverOffset: 4,
-                }]
-            };
-            const categories_config = {
-                type: 'doughnut',
-                data: categories_data,
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: true,
-                    plugins: {
-                        title: {
-                            display: true,
-                            text: "Spend By Category"
-                        }
-                    },
-                    legend: {
-                        display: true,
-                    }
-                }
-            };
-
-            new Chart(document.getElementById('categories_chart'), categories_config);
-        }
-        categoriesChart()
-    </script>
-
-
-{{/*    */}}{{/*Spend Chart*/}}
-{{/*    <script>*/}}
-
-{{/*        function spendChart() {*/}}
-
-
-{{/*            const MONTHS = [*/}}
-{{/*                'January',*/}}
-{{/*                'February',*/}}
-{{/*                'March',*/}}
-{{/*                'April',*/}}
-{{/*                'May',*/}}
-{{/*                'June',*/}}
-{{/*                'July',*/}}
-{{/*                'August',*/}}
-{{/*                'September',*/}}
-{{/*                'October',*/}}
-{{/*                'November',*/}}
-{{/*                'December'*/}}
-{{/*            ];*/}}
-
-{{/*            function months(config) {*/}}
-{{/*                var cfg = config || {};*/}}
-{{/*                var count = cfg.count || 12;*/}}
-{{/*                var section = cfg.section;*/}}
-{{/*                var values = [];*/}}
-{{/*                var i, value;*/}}
-
-{{/*                for (i = 0; i < count; ++i) {*/}}
-{{/*                    value = MONTHS[Math.ceil(i) % 12];*/}}
-{{/*                    values.push(value.substring(0, section));*/}}
-{{/*                }*/}}
-
-{{/*                return values;*/}}
-{{/*            }*/}}
-
-
-{{/*            const spend_labels = months({count: 7});*/}}
-{{/*            const spend_data = {*/}}
-{{/*                labels: spend_labels,*/}}
-{{/*                datasets: [{*/}}
-{{/*                    label: 'My First Dataset',*/}}
-{{/*                    data: [100, 200, -150, 81, 56, 55, 40],*/}}
-{{/*                    backgroundColor: [*/}}
-{{/*                        'rgba(255, 99, 132, 0.2)',*/}}
-{{/*                        'rgba(255, 159, 64, 0.2)',*/}}
-{{/*                        'rgba(255, 205, 86, 0.2)',*/}}
-{{/*                        'rgba(75, 192, 192, 0.2)',*/}}
-{{/*                        'rgba(54, 162, 235, 0.2)',*/}}
-{{/*                        'rgba(153, 102, 255, 0.2)',*/}}
-{{/*                        'rgba(201, 203, 207, 0.2)'*/}}
-{{/*                    ],*/}}
-{{/*                    borderColor: [*/}}
-{{/*                        'rgb(255, 99, 132)',*/}}
-{{/*                        'rgb(255, 159, 64)',*/}}
-{{/*                        'rgb(255, 205, 86)',*/}}
-{{/*                        'rgb(75, 192, 192)',*/}}
-{{/*                        'rgb(54, 162, 235)',*/}}
-{{/*                        'rgb(153, 102, 255)',*/}}
-{{/*                        'rgb(201, 203, 207)'*/}}
-{{/*                    ],*/}}
-{{/*                    borderWidth: 1*/}}
-{{/*                }]*/}}
-{{/*            };*/}}
-{{/*            const spend_config = {*/}}
-{{/*                type: 'bar',*/}}
-{{/*                data: spend_data,*/}}
-{{/*                options: {*/}}
-{{/*                    scales: {*/}}
-{{/*                        y: {*/}}
-{{/*                            beginAtZero: true*/}}
-{{/*                        }*/}}
-{{/*                    }*/}}
-{{/*                },*/}}
-{{/*            };*/}}
-{{/*            new Chart(document.getElementById('spend_chart'), spend_config);*/}}
-{{/*        }*/}}
-{{/*        spendChart()*/}}
-    </script>
-
 {{end}}

--- a/web/templates/home.gohtml
+++ b/web/templates/home.gohtml
@@ -85,13 +85,24 @@
                     <button type="button" class="btn btn-outline-primary">Quarter</button>
                 </div>
             </div>
-            <div class="col">
+{{/*            <div class="col">*/}}
+{{/*                <canvas id="spend_chart" style="min-width: 300px"></canvas>*/}}
+{{/*            </div>*/}}
+
+            <div class="col" hx-trigger="load" hx-get="/charts/timeseries" hx-swap="outerHtml">
                 <canvas id="spend_chart" style="min-width: 300px"></canvas>
             </div>
 
+            <div _="on updateChart log event.detail"></div>
+
         </div>
 
+        <script>
+            document.body.addEventListener("updateChart", function (evt) {
+                console.log(evt)
 
+            })
+        </script>
 
         <hr>
 
@@ -193,84 +204,84 @@
     </script>
 
 
-    {{/*Spend Chart*/}}
-    <script>
+{{/*    */}}{{/*Spend Chart*/}}
+{{/*    <script>*/}}
 
-        function spendChart() {
-
-
-            const MONTHS = [
-                'January',
-                'February',
-                'March',
-                'April',
-                'May',
-                'June',
-                'July',
-                'August',
-                'September',
-                'October',
-                'November',
-                'December'
-            ];
-
-            function months(config) {
-                var cfg = config || {};
-                var count = cfg.count || 12;
-                var section = cfg.section;
-                var values = [];
-                var i, value;
-
-                for (i = 0; i < count; ++i) {
-                    value = MONTHS[Math.ceil(i) % 12];
-                    values.push(value.substring(0, section));
-                }
-
-                return values;
-            }
+{{/*        function spendChart() {*/}}
 
 
-            const spend_labels = months({count: 7});
-            const spend_data = {
-                labels: spend_labels,
-                datasets: [{
-                    label: 'My First Dataset',
-                    data: [65, 59, 80, 81, 56, 55, 40],
-                    backgroundColor: [
-                        'rgba(255, 99, 132, 0.2)',
-                        'rgba(255, 159, 64, 0.2)',
-                        'rgba(255, 205, 86, 0.2)',
-                        'rgba(75, 192, 192, 0.2)',
-                        'rgba(54, 162, 235, 0.2)',
-                        'rgba(153, 102, 255, 0.2)',
-                        'rgba(201, 203, 207, 0.2)'
-                    ],
-                    borderColor: [
-                        'rgb(255, 99, 132)',
-                        'rgb(255, 159, 64)',
-                        'rgb(255, 205, 86)',
-                        'rgb(75, 192, 192)',
-                        'rgb(54, 162, 235)',
-                        'rgb(153, 102, 255)',
-                        'rgb(201, 203, 207)'
-                    ],
-                    borderWidth: 1
-                }]
-            };
-            const spend_config = {
-                type: 'bar',
-                data: spend_data,
-                options: {
-                    scales: {
-                        y: {
-                            beginAtZero: true
-                        }
-                    }
-                },
-            };
-            new Chart(document.getElementById('spend_chart'), spend_config);
-        }
-        spendChart()
+{{/*            const MONTHS = [*/}}
+{{/*                'January',*/}}
+{{/*                'February',*/}}
+{{/*                'March',*/}}
+{{/*                'April',*/}}
+{{/*                'May',*/}}
+{{/*                'June',*/}}
+{{/*                'July',*/}}
+{{/*                'August',*/}}
+{{/*                'September',*/}}
+{{/*                'October',*/}}
+{{/*                'November',*/}}
+{{/*                'December'*/}}
+{{/*            ];*/}}
+
+{{/*            function months(config) {*/}}
+{{/*                var cfg = config || {};*/}}
+{{/*                var count = cfg.count || 12;*/}}
+{{/*                var section = cfg.section;*/}}
+{{/*                var values = [];*/}}
+{{/*                var i, value;*/}}
+
+{{/*                for (i = 0; i < count; ++i) {*/}}
+{{/*                    value = MONTHS[Math.ceil(i) % 12];*/}}
+{{/*                    values.push(value.substring(0, section));*/}}
+{{/*                }*/}}
+
+{{/*                return values;*/}}
+{{/*            }*/}}
+
+
+{{/*            const spend_labels = months({count: 7});*/}}
+{{/*            const spend_data = {*/}}
+{{/*                labels: spend_labels,*/}}
+{{/*                datasets: [{*/}}
+{{/*                    label: 'My First Dataset',*/}}
+{{/*                    data: [100, 200, -150, 81, 56, 55, 40],*/}}
+{{/*                    backgroundColor: [*/}}
+{{/*                        'rgba(255, 99, 132, 0.2)',*/}}
+{{/*                        'rgba(255, 159, 64, 0.2)',*/}}
+{{/*                        'rgba(255, 205, 86, 0.2)',*/}}
+{{/*                        'rgba(75, 192, 192, 0.2)',*/}}
+{{/*                        'rgba(54, 162, 235, 0.2)',*/}}
+{{/*                        'rgba(153, 102, 255, 0.2)',*/}}
+{{/*                        'rgba(201, 203, 207, 0.2)'*/}}
+{{/*                    ],*/}}
+{{/*                    borderColor: [*/}}
+{{/*                        'rgb(255, 99, 132)',*/}}
+{{/*                        'rgb(255, 159, 64)',*/}}
+{{/*                        'rgb(255, 205, 86)',*/}}
+{{/*                        'rgb(75, 192, 192)',*/}}
+{{/*                        'rgb(54, 162, 235)',*/}}
+{{/*                        'rgb(153, 102, 255)',*/}}
+{{/*                        'rgb(201, 203, 207)'*/}}
+{{/*                    ],*/}}
+{{/*                    borderWidth: 1*/}}
+{{/*                }]*/}}
+{{/*            };*/}}
+{{/*            const spend_config = {*/}}
+{{/*                type: 'bar',*/}}
+{{/*                data: spend_data,*/}}
+{{/*                options: {*/}}
+{{/*                    scales: {*/}}
+{{/*                        y: {*/}}
+{{/*                            beginAtZero: true*/}}
+{{/*                        }*/}}
+{{/*                    }*/}}
+{{/*                },*/}}
+{{/*            };*/}}
+{{/*            new Chart(document.getElementById('spend_chart'), spend_config);*/}}
+{{/*        }*/}}
+{{/*        spendChart()*/}}
     </script>
 
 {{end}}

--- a/web/templates/layout.gohtml
+++ b/web/templates/layout.gohtml
@@ -40,6 +40,7 @@
 
         <script>
             htmx.config.useTemplateFragments = true
+            // htmx.logAll()
         </script>
     </head>
 

--- a/web/templates/merchants.gohtml
+++ b/web/templates/merchants.gohtml
@@ -6,6 +6,7 @@
         <table class="table">
             <thead>
             <tr>
+                <th> Id</th>
                 <th> Name</th>
                 <th> Category</th>
                 <th> Edit</th>
@@ -16,6 +17,7 @@
             {{- /*gotype:github.com/TheQueenIsDead/budge/pkg.Merchant*/ -}}
             {{ range . }}
                 <tr>
+                    <td>{{ .Id }}</td>
                     <td>{{ .Name }}</td>
                     <td>{{ .Category }}</td>
                     <td>


### PR DESCRIPTION
Adds a timeseries display to the home page that shows spend over time
Creates a re-usable gotemplate for chartjs charts

TODO:
 - Fix the change in chart display bug where chartjs does not resize corectly.
 - Bucket the datapoints over time by aggregating (Ex, if period is quarter, make a bucket a month)
 - If period is a week, use friendly Day names (Monday...Etc)