### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/pkg/application/inventory.go
+++ b/pkg/application/inventory.go
@@ -35,6 +35,9 @@ func (app *Application) InventoryCreate(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, err.Error())
 	}
+	if quantity < math.MinInt || quantity > math.MaxInt {
+		return c.String(http.StatusBadRequest, "quantity out of bounds")
+	}
 	dateString := c.Request().FormValue("date")
 	date, err := time.Parse("2006-01-02", dateString)
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/TheQueenIsDead/budge/security/code-scanning/2](https://github.com/TheQueenIsDead/budge/security/code-scanning/2)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to an `int` type is safe. This can be achieved by adding bounds checks to ensure that the parsed integer value fits within the range of the `int` type before performing the conversion.

The best way to fix this issue is to:
1. Parse the integer value with the correct bit size using `strconv.ParseInt`.
2. Check that the parsed value is within the bounds of the `int` type.
3. Perform the conversion only if the value is within bounds; otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
